### PR TITLE
Use python 3 as default

### DIFF
--- a/PythonAPI/Makefile
+++ b/PythonAPI/Makefile
@@ -1,9 +1,9 @@
 all:
     # install pycocotools locally
-	python setup.py build_ext --inplace
+	python3 setup.py build_ext --inplace
 	rm -rf build
 
 install:
 	# install pycocotools to the Python site-packages
-	python setup.py build_ext install
+	python3 setup.py build_ext install
 	rm -rf build

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -8,7 +8,7 @@ ext_modules = [
     Extension(
         'pycocotools._mask',
         sources=['../common/maskApi.c', 'pycocotools/_mask.pyx'],
-        include_dirs = [np.get_include(), '../common'],
+        include_dirs=[np.get_include(), '../common'],
         extra_compile_args=['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
     )
 ]
@@ -16,12 +16,13 @@ ext_modules = [
 setup(
     name='pycocotools',
     packages=['pycocotools'],
-    package_dir = {'pycocotools': 'pycocotools'},
+    package_dir={'pycocotools': 'pycocotools'},
     install_requires=[
         'setuptools>=18.0',
         'cython>=0.27.3',
-        'matplotlib>=2.1.0'
+        'pyparsing<3.0',  # We need an older pyparsing version which is compatible with TF 1
+        'matplotlib>=2.1.0,<3.4'  # matplotlib 3.4 uses python 3.7, we are using python 3.6.8
     ],
     version='2.0',
-    ext_modules= ext_modules
+    ext_modules=ext_modules
 )


### PR DESCRIPTION
We want to use the Makefile in the Thoth build scripts. Some modifications are needed (pin python and module versions).